### PR TITLE
Fix app initialization to work without Ollama connection

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -4,25 +4,25 @@ document.addEventListener('DOMContentLoaded', async () => {
     
     const tokenCounter = new TokenCounter();
     
+    const promptLibrary = new PromptLibrary(ollamaClient);
+    const chatManager = new ChatManager(ollamaClient, openaiClient, tokenCounter, promptLibrary);
+    
     try {
         const models = await ollamaClient.fetchModels();
         console.log('Available Ollama models:', models);
-        
-        const contextLimits = {
-            ...ollamaClient.getAllModelContextLimits(),
-            ...openaiClient.getAllModelContextLimits()
-        };
-        tokenCounter.setModelContextLimits(contextLimits);
-        
-        const promptLibrary = new PromptLibrary(ollamaClient);
-        
-        const chatManager = new ChatManager(ollamaClient, openaiClient, tokenCounter, promptLibrary);
-        
-        Utils.showToast('Anwendung initialisiert', 'success');
+        Utils.showToast('Ollama-Verbindung hergestellt', 'success');
     } catch (error) {
-        console.error('Error initializing app:', error);
-        Utils.showToast('Fehler bei der Initialisierung. Bitte überprüfen Sie die Verbindung.', 'error');
+        console.warn('Ollama not available:', error);
+        Utils.showToast('Ollama nicht verfügbar - nur OpenAI-Modelle verfügbar', 'warning');
     }
+    
+    const contextLimits = {
+        ...ollamaClient.getAllModelContextLimits(),
+        ...openaiClient.getAllModelContextLimits()
+    };
+    tokenCounter.setModelContextLimits(contextLimits);
+    
+    Utils.showToast('Anwendung initialisiert', 'success');
     
     window.addEventListener('click', (event) => {
         document.querySelectorAll('.modal').forEach(modal => {

--- a/public/js/chat-manager.js
+++ b/public/js/chat-manager.js
@@ -327,6 +327,10 @@ class ChatManager {
             const defaultModel = `ollama:${this.ollamaClient.models[0].name}`;
             modelSelector.value = defaultModel;
             this.setModel(chatId, defaultModel);
+        } else if (openaiModels.length > 0) {
+            const defaultModel = `openai:${openaiModels[0].name}`;
+            modelSelector.value = defaultModel;
+            this.setModel(chatId, defaultModel);
         }
         
         this.updateTokenDisplay(chatId);
@@ -634,13 +638,21 @@ class ChatManager {
         this.connectionText.textContent = 'Verbindung prüfen...';
         
         try {
-            const isConnected = await this.ollamaClient.checkConnection();
-            if (isConnected) {
+            const ollamaConnected = await this.ollamaClient.checkConnection();
+            const openaiConnected = await this.openaiClient.checkConnection();
+            
+            if (ollamaConnected && openaiConnected) {
                 this.connectionIndicator.className = 'connection-led connected';
-                this.connectionText.textContent = 'Verbunden';
+                this.connectionText.textContent = 'Ollama & OpenAI verbunden';
+            } else if (ollamaConnected) {
+                this.connectionIndicator.className = 'connection-led connected';
+                this.connectionText.textContent = 'Ollama verbunden';
+            } else if (openaiConnected) {
+                this.connectionIndicator.className = 'connection-led connected';
+                this.connectionText.textContent = 'OpenAI verbunden';
             } else {
                 this.connectionIndicator.className = 'connection-led';
-                this.connectionText.textContent = 'Getrennt';
+                this.connectionText.textContent = 'Keine Verbindung';
             }
         } catch (error) {
             this.connectionIndicator.className = 'connection-led';


### PR DESCRIPTION
- Move ChatManager initialization outside try-catch block so UI components are always created
- Update model selector to fallback to OpenAI models when no Ollama models available
- Improve connection status checking to show both Ollama and OpenAI status
- Ensure Settings and Prompt Library buttons work even when Ollama is not available

Fixes issue where buttons were non-functional without Ollama connection.